### PR TITLE
Add AI provider selection with models and prompt instructions

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,12 +1,37 @@
 import { type CoreMessage, streamText } from "ai";
 import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
 
 export async function POST(req: Request) {
-  const { messages }: { messages: CoreMessage[] } = await req.json();
+  const {
+    messages,
+    provider = "google",
+    apiKey,
+    model,
+    instructions = "You are a helpful assistant.",
+  }: {
+    messages: CoreMessage[];
+    provider?: string;
+    apiKey?: string;
+    model?: string;
+    instructions?: string;
+  } = await req.json();
+
+  let modelProvider;
+  if (provider === "openai") {
+    modelProvider = openai(model ?? "gpt-4o", { apiKey });
+  } else if (provider === "deepseek") {
+    modelProvider = openai(model ?? "deepseek-chat", {
+      apiKey,
+      baseUrl: "https://api.deepseek.com",
+    });
+  } else {
+    modelProvider = google(model ?? "gemini-2.5-flash-preview-04-17", { apiKey });
+  }
 
   const result = streamText({
-    model: google("gemini-2.5-flash-preview-04-17"),
-    system: "You are a helpful assistant.",
+    model: modelProvider,
+    system: instructions,
     messages,
   });
 

--- a/components/chat-form.tsx
+++ b/components/chat-form.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 
 import { useChat } from "@ai-sdk/react";
+import { useState, useEffect } from "react";
 
 import { ArrowUpIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -17,8 +18,23 @@ export function ChatForm({
   className,
   ...props
 }: React.ComponentProps<"form">) {
+  const [provider, setProvider] = useState("google");
+  const [apiKey, setApiKey] = useState("");
+  const modelsByProvider: Record<string, string[]> = {
+    google: ["gemini-2.5-flash-preview-04-17", "gemini-pro"],
+    openai: ["gpt-4o", "gpt-4-turbo", "gpt-3.5-turbo"],
+    deepseek: ["deepseek-chat"],
+  };
+  const [model, setModel] = useState(modelsByProvider[provider][0]);
+  const [instructions, setInstructions] = useState("You are a helpful assistant.");
+
+  useEffect(() => {
+    setModel(modelsByProvider[provider][0]);
+  }, [provider]);
+
   const { messages, input, setInput, append } = useChat({
     api: "/api/chat",
+    body: { provider, apiKey, model, instructions },
   });
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -65,6 +81,61 @@ export function ChatForm({
     </div>
   );
 
+  const settings = (
+    <div className="my-4 flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <label className="w-24 text-sm">AI Provider</label>
+        <select
+          className="flex-1 rounded-md border bg-background px-2 py-1"
+          value={provider}
+          onChange={(e) => setProvider(e.target.value)}
+          disabled={messages.length > 0}
+        >
+          <option value="google">Google</option>
+          <option value="openai">OpenAI</option>
+          <option value="deepseek">Deepseek</option>
+        </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="w-24 text-sm">API Key</label>
+        <input
+          type="password"
+          className="flex-1 rounded-md border bg-background px-2 py-1"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          disabled={messages.length > 0}
+          placeholder="API Key"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="w-24 text-sm">Model</label>
+        <select
+          className="flex-1 rounded-md border bg-background px-2 py-1"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          disabled={messages.length > 0}
+        >
+          {modelsByProvider[provider].map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="w-24 text-sm">Instructions</label>
+        <input
+          type="text"
+          className="flex-1 rounded-md border bg-background px-2 py-1"
+          value={instructions}
+          onChange={(e) => setInstructions(e.target.value)}
+          disabled={messages.length > 0}
+          placeholder="System instructions"
+        />
+      </div>
+    </div>
+  );
+
   return (
     <main
       className={cn(
@@ -72,8 +143,9 @@ export function ChatForm({
         className
       )}
       {...props}
-    >
+   >
       <div className="flex-1 content-center overflow-y-auto px-6">
+        {settings}
         {messages.length ? messageList : header}
       </div>
       <form


### PR DESCRIPTION
## Summary
- add provider, key, model and instructions options to ChatForm
- support Google, OpenAI and Deepseek providers in API route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b3b9f7048320926f5f1caec61cf6